### PR TITLE
Fix non-existent module `eval` in code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ The single machine implementation starts from the [eval/main.py](eval/main.py), 
 
 For example, to run ImageNet image classification on GPUs "0","1", and "2" on a local machine using the config [configs/eval/vitl16_in1k.yaml](configs/eval/vitl16_in1k.yaml), type the command:
 ```
-python -m eval.main \
+python -m evals.main \
   --fname configs/eval/vitl16_in1k.yaml \
   --devices cuda:0 cuda:1 cuda:2
 ```
@@ -367,7 +367,7 @@ To launch a distributed evaluation run, the implementation starts from [eval/mai
 
 For example, to launch a distributed ImageNet image classification experiment using the config [configs/eval/vitl16_in1k.yaml](configs/eval/vitl16_in1k.yaml), type the command:
 ```
-python -m eval.main_distributed \
+python -m evals.main_distributed \
   --fname configs/eval/vitl16_in1k.yaml \
   --folder $path_to_save_stderr_and_stdout \
   --partition $slurm_partition
@@ -375,7 +375,7 @@ python -m eval.main_distributed \
 
 Similarly, to launch a distributed K400 video classificaiton experiment using the config [configs/eval/vitl16_k400.yaml](configs/eval/vitl16_k400.yaml), type the command:
 ```
-python -m eval.main_distributed \
+python -m evals.main_distributed \
   --fname configs/eval/vitl16_k400.yaml \
   --folder $path_to_save_stderr_and_stdout \
   --partition $slurm_partition


### PR DESCRIPTION
It looks as if the `evals` directory was formerly `eval` (it was renamed) because I see these code snippets referencing it like that.

This PR changes those references, but let me know if you prefer me to do the opposite change (rename the directory and imports).