### PR TITLE
Fix `make_videodataset` when `num_workers=0`

### DIFF
--- a/src/datasets/video_dataset.py
+++ b/src/datasets/video_dataset.py
@@ -94,7 +94,7 @@ def make_videodataset(
         drop_last=drop_last,
         pin_memory=pin_mem,
         num_workers=num_workers,
-        persistent_workers=True)
+        persistent_workers=num_workers > 0)
     logger.info('VideoDataset unsupervised data loader created')
 
     return dataset, data_loader, dist_sampler


### PR DESCRIPTION
When using a serial `DataLoader` (0 data workers; e.g., for debugging purposes), the program crashes because `persistent_workers=True` can't be used with a serial data loader. This PR fixes this.