### PR TITLE
Fix `drop_last=True` in the data loader for video evaluation

### DIFF
--- a/src/datasets/data_manager.py
+++ b/src/datasets/data_manager.py
@@ -85,6 +85,7 @@ def init_data(
             num_workers=num_workers,
             world_size=world_size,
             rank=rank,
+            drop_last=drop_last,
             log_dir=log_dir)
 
     return (data_loader, dist_sampler)


### PR DESCRIPTION
The argument `drop_last=droplast` (which by default is `True`) was absent when calling `make_videodataset` from `init_data`. This could make the video results change a bit, depending on the batch size used and the dataset length.