### PR TITLE
Make the setup instructions more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Run:
 ```bash
 conda create -n jepa python=3.9 pip
 conda activate jepa
-pip install -e .
+python setup.py install
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -385,8 +385,13 @@ python -m evals.main_distributed \
 ---
 
 ### Setup
-Create a new Conda environment, activate it, and run the [setup.py](setup.py) script:
-`python setup.py install`
+
+Run:
+```bash
+conda create -n jepa python=3.9 pip
+conda activate jepa
+pip install -e .
+```
 
 ## License
 See the [LICENSE](./LICENSE) file for details about the license under which this code is made available.


### PR DESCRIPTION
Note that [`pip install -e .` is preferred over `python setup.py install`](https://stackoverflow.com/questions/15724093/difference-between-python-setup-py-install-and-pip-install).