### PR TITLE
For evals, only shuffle for training

### DIFF
--- a/src/datasets/data_manager.py
+++ b/src/datasets/data_manager.py
@@ -63,6 +63,7 @@ def init_data(
             persistent_workers=persistent_workers,
             copy_data=copy_data,
             drop_last=drop_last,
+            shuffle=training,
             subset_file=subset_file)
 
     elif data.lower() == 'videodataset':
@@ -86,6 +87,7 @@ def init_data(
             world_size=world_size,
             rank=rank,
             drop_last=drop_last,
+            shuffle=training,
             log_dir=log_dir)
 
     return (data_loader, dist_sampler)

--- a/src/datasets/image_dataset.py
+++ b/src/datasets/image_dataset.py
@@ -53,6 +53,7 @@ def make_imagedataset(
     copy_data=False,
     drop_last=True,
     persistent_workers=False,
+    shuffle=True,
     subset_file=None
 ):
     dataset = ImageFolder(
@@ -64,7 +65,8 @@ def make_imagedataset(
     dist_sampler = torch.utils.data.distributed.DistributedSampler(
         dataset=dataset,
         num_replicas=world_size,
-        rank=rank)
+        rank=rank,
+        shuffle=shuffle)
     data_loader = torch.utils.data.DataLoader(
         dataset,
         collate_fn=collator,

--- a/src/datasets/video_dataset.py
+++ b/src/datasets/video_dataset.py
@@ -44,6 +44,7 @@ def make_videodataset(
     num_workers=10,
     pin_mem=True,
     duration=None,
+    shuffle=True,
     log_dir=None,
 ):
     dataset = VideoDataset(
@@ -72,7 +73,7 @@ def make_videodataset(
             dataset,
             num_replicas=world_size,
             rank=rank,
-            shuffle=True)
+            shuffle=shuffle)
 
     data_loader = torch.utils.data.DataLoader(
         dataset,


### PR DESCRIPTION
I think shuffling only during training makes it better for debugging on the validation data and more predictable.