### PR TITLE
Add Hugging Face discoverability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ decord
 pandas
 einops
 beartype
-git+https://github.com/huggingface/huggingface_hub.git
+huggingface_hub>=0.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ decord
 pandas
 einops
 beartype
+git+https://github.com/huggingface/huggingface_hub.git

--- a/src/models/vision_transformer.py
+++ b/src/models/vision_transformer.py
@@ -37,6 +37,7 @@ class VisionTransformer(nn.Module, PyTorchModelHubMixin, library_name="v-jepa", 
         qk_scale=None,
         drop_rate=0.0,
         attn_drop_rate=0.0,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), 
         init_std=0.02,
         out_layers=None,
         uniform_power=False,
@@ -44,7 +45,6 @@ class VisionTransformer(nn.Module, PyTorchModelHubMixin, library_name="v-jepa", 
     ):
         super().__init__()
 
-        norm_layer = partial(nn.LayerNorm, eps=1e-6)
         self.num_features = self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.out_layers = out_layers
@@ -252,49 +252,49 @@ class VisionTransformer(nn.Module, PyTorchModelHubMixin, library_name="v-jepa", 
 def vit_tiny(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=192, depth=12, num_heads=3, mlp_ratio=4,
-        qkv_bias=True, **kwargs)
+        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
     return model
 
 
 def vit_small(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=384, depth=12, num_heads=6, mlp_ratio=4,
-        qkv_bias=True, **kwargs)
+        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
     return model
 
 
 def vit_base(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=768, depth=12, num_heads=12, mlp_ratio=4,
-        qkv_bias=True, **kwargs)
+        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
     return model
 
 
 def vit_large(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=1024, depth=24, num_heads=16, mlp_ratio=4,
-        qkv_bias=True, **kwargs)
+        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
     return model
 
 
 def vit_huge(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=1280, depth=32, num_heads=16, mlp_ratio=4,
-        qkv_bias=True, **kwargs)
+        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
     return model
 
 
 def vit_giant(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=1408, depth=40, num_heads=16, mlp_ratio=48/11,
-        qkv_bias=True, **kwargs)
+        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
     return model
 
 
 def vit_gigantic(patch_size=14, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=1664, depth=48, num_heads=16, mpl_ratio=64/13,
-        qkv_bias=True, **kwargs
+        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs
     )
     return model
 

--- a/src/models/vision_transformer.py
+++ b/src/models/vision_transformer.py
@@ -44,7 +44,7 @@ class VisionTransformer(nn.Module, PyTorchModelHubMixin):
     ):
         super().__init__()
 
-        norm_layer = partial(norm_layer, eps=1e-6)
+        norm_layer = partial(nn.LayerNorm, eps=1e-6)
         self.num_features = self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.out_layers = out_layers

--- a/src/models/vision_transformer.py
+++ b/src/models/vision_transformer.py
@@ -20,7 +20,7 @@ from src.masks.utils import apply_masks
 from huggingface_hub import PyTorchModelHubMixin
 
 
-class VisionTransformer(nn.Module, PyTorchModelHubMixin):
+class VisionTransformer(nn.Module, PyTorchModelHubMixin, library_name="v-jepa", tags=["video-embeddings"], repo_url="https://github.com/facebookresearch/jepa"):
     """ Vision Transformer """
     def __init__(
         self,

--- a/src/models/vision_transformer.py
+++ b/src/models/vision_transformer.py
@@ -20,7 +20,7 @@ from src.masks.utils import apply_masks
 from huggingface_hub import PyTorchModelHubMixin
 
 
-class VisionTransformer(nn.Module, PyTorchModelHubMixin, library_name="v-jepa", tags=["video-embeddings"], repo_url="https://github.com/facebookresearch/jepa"):
+class VisionTransformer(nn.Module, PyTorchModelHubMixin, library_name="v-jepa", tags=["video-feature-extraction"], repo_url="https://github.com/facebookresearch/jepa"):
     """ Vision Transformer """
     def __init__(
         self,
@@ -44,7 +44,6 @@ class VisionTransformer(nn.Module, PyTorchModelHubMixin, library_name="v-jepa", 
         **kwargs
     ):
         super().__init__()
-
         self.num_features = self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.out_layers = out_layers

--- a/src/models/vision_transformer.py
+++ b/src/models/vision_transformer.py
@@ -17,8 +17,10 @@ from src.models.utils.pos_embs import get_2d_sincos_pos_embed, get_3d_sincos_pos
 from src.utils.tensors import trunc_normal_
 from src.masks.utils import apply_masks
 
+from huggingface_hub import PyTorchModelHubMixin
 
-class VisionTransformer(nn.Module):
+
+class VisionTransformer(nn.Module, PyTorchModelHubMixin):
     """ Vision Transformer """
     def __init__(
         self,
@@ -35,13 +37,14 @@ class VisionTransformer(nn.Module):
         qk_scale=None,
         drop_rate=0.0,
         attn_drop_rate=0.0,
-        norm_layer=nn.LayerNorm,
         init_std=0.02,
         out_layers=None,
         uniform_power=False,
         **kwargs
     ):
         super().__init__()
+
+        norm_layer = partial(norm_layer, eps=1e-6)
         self.num_features = self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.out_layers = out_layers
@@ -249,49 +252,49 @@ class VisionTransformer(nn.Module):
 def vit_tiny(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=192, depth=12, num_heads=3, mlp_ratio=4,
-        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
+        qkv_bias=True, **kwargs)
     return model
 
 
 def vit_small(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=384, depth=12, num_heads=6, mlp_ratio=4,
-        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
+        qkv_bias=True, **kwargs)
     return model
 
 
 def vit_base(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=768, depth=12, num_heads=12, mlp_ratio=4,
-        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
+        qkv_bias=True, **kwargs)
     return model
 
 
 def vit_large(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=1024, depth=24, num_heads=16, mlp_ratio=4,
-        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
+        qkv_bias=True, **kwargs)
     return model
 
 
 def vit_huge(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=1280, depth=32, num_heads=16, mlp_ratio=4,
-        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
+        qkv_bias=True, **kwargs)
     return model
 
 
 def vit_giant(patch_size=16, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=1408, depth=40, num_heads=16, mlp_ratio=48/11,
-        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
+        qkv_bias=True, **kwargs)
     return model
 
 
 def vit_gigantic(patch_size=14, **kwargs):
     model = VisionTransformer(
         patch_size=patch_size, embed_dim=1664, depth=48, num_heads=16, mpl_ratio=64/13,
-        qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs
+        qkv_bias=True, **kwargs
     )
     return model
 


### PR DESCRIPTION
Hi @MidoAssran and team, thanks for this great model!

Currently models aren't easily discoverable, there are no JEPA models on the 🤗 hub, so this PR proposes to leverage the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) which is a minimal class to add `from_pretrained` and `push_to_hub` capabilities to any custom `nn.Module`.

All you need to do is inherit from this class, and then you can do:

```python
from src.models.vision_transformer import VisionTransformer

model = VisionTransformer.from_pretrained("nielsr/vit-large-patch16-v-jepa")
```
This also comes with automated download metrics, meaning you will be able to see how many times people use each of the various JEPA models.

The model is here for now: https://huggingface.co/nielsr/vit-large-patch16-v-jepa, but we could push and move all checkpoints to the Meta [organization](https://huggingface.co/facebook) on the 🤗 hub.

Here's a [notebook](https://colab.research.google.com/drive/1wRupy5vOkIsQ4BrNtqeaCVwVgnopTlx8?usp=sharing) to showcase it end-to-end.

Kind regards,

Niels
ML @ HF