### PR TITLE
Fix main_distributed.py count for total nodes and tasks_per_node

### DIFF
--- a/app/main_distributed.py
+++ b/app/main_distributed.py
@@ -121,13 +121,13 @@ def launch():
     # ---------------------------------------------------------------------- #
     # 2. Parse each yaml config file as a dict and place in list
     # ---------------------------------------------------------------------- #
-    nodes, tasks_per_node = None, None
+    nodes, tasks_per_node = 0, 0
     configs = []
     for f in config_fnames:
         with open(f, 'r') as y_file:
             _params = yaml.load(y_file, Loader=yaml.FullLoader)
-            nodes = int(_params.get('nodes'))
-            tasks_per_node = int(_params.get('tasks_per_node'))
+            nodes += int(_params.get('nodes'))
+            tasks_per_node += int(_params.get('tasks_per_node'))
             configs += [_params]
     logger.info(f'Loaded {len(configs)} config files')
     logger.info(f'Running all jobs with {nodes=} / {tasks_per_node=}')


### PR DESCRIPTION
Fix nodes and tasks_per_node accumulation in `app/main_distributed.py`

When processing multiple config files, we should accumulate the total number  of nodes and tasks_per_node across all configs instead of just using the values from the last config file.

Changes to node and task count initialization and accumulation:
 - Changed initialization of `nodes` and `tasks_per_node` from `None` to `0`
 - Modified accumulation logic in `launch()` function to use `+=` instead of `=` for summing values across configs
 - Ensures logged values reflect total cluster resources needed when batch-launching jobs

This better reflects the intended behavior of tracking total resource 
requirements when batch-launching multiple jobs.